### PR TITLE
Update Dockerfile: Install tini-static from apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN mkdir -p /opt/JDownloader/ && \
     apk add wget  --virtual .build-deps && \
     wget -O /opt/JDownloader/JDownloader.jar "http://installer.jdownloader.org/JDownloader.jar?$RANDOM" && \
     chmod +x /opt/JDownloader/JDownloader.jar && \
-    wget -O /usr/bin/tini "https://github.com/krallin/tini/releases/download/v0.18.0/tini-static-${ARCH}" --no-check-certificate && \
-    chmod +x /usr/bin/tini && \
     chmod 777 /opt/JDownloader/ -R && \
+    apk add --no-cache tini-static && \
     apk del wget --purge .build-deps && \
     rm /usr/bin/qemu-*-static
 
@@ -31,4 +30,4 @@ COPY configure.sh /usr/bin/configure
 
 WORKDIR /opt/JDownloader
 
-CMD ["tini", "--", "/opt/JDownloader/daemon.sh"]
+CMD ["tini-static", "--", "/opt/JDownloader/daemon.sh"]


### PR DESCRIPTION
Per the `tini` documentation, it is possible to install `tini` (and `tini-static`) directly via `apk add` under Alpine Linux. Unless there is a reason to not use the newest `tini` version, I would suggest to use that mechanism, as it is much simpler and potentially less error prone than downloading via wget.

```
RUN apk add --no-cache tini-static
# Some other code
CMD ["tini-static", "--", "/opt/JDownloader/daemon.sh"]
```