### PR TITLE
Add support for root-only distros like LibreElec/CoreElec (Kodi)

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,29 @@
+FROM arm64v8/openjdk:jre-alpine as builder
+FROM builder
+
+ARG ARCH=arm64
+ARG VERSION="1.0.0"
+
+LABEL maintainer="Jay MOULIN <jaymoulin@gmail.com> <https://twitter.com/MoulinJay>"
+LABEL version="${VERSION}-${ARCH}"
+
+COPY ./${ARCH}/*.jar /opt/JDownloader/libs/
+# archive extraction uses sevenzipjbinding library
+# which is compiled against libstdc++
+
+RUN mkdir -p /opt/JDownloader/libs && \
+    apk add --no-cache --quiet tini su-exec shadow ffmpeg jq libstdc++ && \
+    apk add wget  --virtual .build-deps && \
+    wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" http://installer.jdownloader.org/JDownloader.jar && \
+    apk del wget --purge .build-deps && \
+    java -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar
+
+COPY entrypoint.sh /opt/JDownloader/
+
+EXPOSE 3129
+WORKDIR /opt/JDownloader
+
+ENTRYPOINT ["tini", "-g", "--", "/opt/JDownloader/entrypoint.sh"]
+# Run this when the container is started
+CMD ["java", "-Djava.awt.headless=true", "-jar", "/opt/JDownloader/JDownloader.jar"]
+

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -11,8 +11,7 @@ COPY ./${ARCH}/*.jar /opt/JDownloader/libs/
 # archive extraction uses sevenzipjbinding library
 # which is compiled against libstdc++
 
-RUN mkdir -p /opt/JDownloader/libs && \
-    apk add --no-cache --quiet tini su-exec shadow ffmpeg jq libstdc++ && \
+RUN apk add --no-cache --quiet tini su-exec shadow ffmpeg jq libstdc++ && \
     apk add wget  --virtual .build-deps && \
     wget -O /opt/JDownloader/JDownloader.jar --user-agent="https://hub.docker.com/r/plusminus/jdownloader2-headless/" http://installer.jdownloader.org/JDownloader.jar && \
     apk del wget --purge .build-deps && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Set defaults for uid and gid to not be root
+if [ -z $GID ]; then GID=100;  fi
+if [ -z $UID ]; then UID=1000; fi
+
+if [ "$GID" -ne "0" ]; then
+	GROUP=jdownloader
+	groupadd -g $GID $GROUP
+else
+	GROUP=root
+fi
+
+if [ "$UID" -ne "0" ]; then
+    USER=jdownloader
+
+    # Create user without home (-M) and remove login shell
+    useradd -M -s /bin/false -g $GID -u $UID $USER
+else
+    USER=root
+    usermod -ag $GID
+fi
+
+# Set MyJDownloader credentials
+CONFIG_FILE="/opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json"
+if [ ! -z "$EMAIL" ] ; then
+    if [ ! -f "$CONFIG_FILE" ] || [ ! -s "$CONFIG_FILE" ] ; then
+        echo '{}' > "$CONFIG_FILE"
+    fi
+
+    CFG=$(jq -r --arg EMAIL "$EMAIL" --arg PASSWORD "$PASSWORD" '.email = $EMAIL | .password = $PASSWORD' "$CONFIG_FILE")
+    [ ! -z "$CFG" ] && echo "$CFG" > "$CONFIG_FILE"
+fi
+
+chown -R $UID:$GID /opt/JDownloader
+
+# Sometimes this gets deleted. Just copy it every time.
+#cp /opt/JDownloader/sevenzip* /opt/JDownloader/libs/
+
+su-exec ${UID}:${GID} "$@"
+
+# Keep container alive when jd2 restarts
+while sleep 3600; do :; done


### PR DESCRIPTION
Hi @jaymoulin ,

I added and changed 2 files which I took from https://github.com/PlusMinus0/headless-jd2-docker.

The main changes are:

- User "jdownloader:jdownloader" is added to the image. This fixes an issue I had with the docker image you provide. Running JDownloader.jar as root in a root owned folder causes the update process of JDownloader to crash with an exception and restart the update process again, which lead to an infinite loop. Starting JDownloader.jar with an non-root user fixes the issue for me.

- The JDownloader update process is launched while building image. No need to restart the docker container on first run and no need to mess with java pids.

I and I think many Kodi users running LibreElec/CoreElec would really appreciate it, if you could implement the said changes to your docker images.

Thanks!
