### PR TITLE
added Volume for /opt/JDownloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ENV LD_LIBRARY_PATH=/lib;/lib32;/usr/lib
 ENV XDG_DOWNLOAD_DIR=/opt/JDownloader/Downloads
 ENV UMASK=''
 
+VOLUME /opt/JDownloader
+
 COPY ./${ARCH}/*.jar /opt/JDownloader/libs/
 # archive extraction uses sevenzipjbinding library
 # which is compiled against libstdc++


### PR DESCRIPTION
This should allow a volume mount at /opt/JDownloader without ending up with e empty directory (as discussed in #82). As per documentation [1], using `VOLUME` should copy the pre existing files into the mount.

However, due to some issues with my local dev environment, I'm currently not able to test that, as I'm not able to do multi-arch builds right now. However, from my experience developing docker containers, this change shouldn't break anything.

If this works (and you are interested), I'm happy to provide some additions to the readme for Kubernetes deployments and also a sample deployment if needed. Just let me know.

[1]: https://docs.docker.com/engine/reference/builder/#volume