### PR TITLE
Use app folder for main JDownloader files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here are some examples to get started with the creation of this container.
 
 ### Docker
 ```
-docker run -d --init --restart=always -v </path/to/downloads>:/opt/JDownloader/Downloads -v </path/to/appdata/config>:/opt/JDownloader/cfg --name jdownloader -u $(id -u) -p 3129:3129 -e MYJD_USER=email@email.com -e MYJD_PASSWORD=bar -e MYJD_DEVICE_NAME=goofy jaymoulin/jdownloader
+docker run -d --init --restart=always -v </path/to/downloads>:/opt/JDownloader/Downloads -v </path/to/appdata/config>:/opt/JDownloader/app/cfg --name jdownloader -u $(id -u) -p 3129:3129 -e MYJD_USER=email@email.com -e MYJD_PASSWORD=bar -e MYJD_DEVICE_NAME=goofy jaymoulin/jdownloader
 ```
 ### Docker Compose
 ```yml
@@ -36,9 +36,9 @@ services:
     restart: always
     user: 1001:100
     volumes:
-        - </path/to/appdata/config>:/opt/JDownloader/cfg
+        - </path/to/appdata/config>:/opt/JDownloader/app/cfg
         - </path/to/downloads>:/opt/JDownloader/Downloads
-        - </path/to/appdata/logs>:/opt/JDownloader/logs #optional
+        - </path/to/appdata/logs>:/opt/JDownloader/app/logs #optional
         - /etc/localtime:/etc/localtime:ro #optional
     environment: 
             MYJD_USER: email@email.com #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
@@ -58,8 +58,8 @@ You can set many parameters when you configure this container, but you must spec
 ### Configuration values 
 | Parameter | Function |
 | :----: | --- |
-| `-v /opt/JDownloader/cfg`| Config file folder, saves your configuration on the host |
-| `-v /opt/JDownloader/logs` | Container logs folder, specify it only if you wan to keep logs on the host |
+| `-v /opt/JDownloader/app/cfg`| Config file folder, saves your configuration on the host |
+| `-v /opt/JDownloader/app/logs` | Container logs folder, specify it only if you wan to keep logs on the host |
 | `-v /opt/JDownloader/Downloads` | Downloads folder (where you put your `download` mountpoint) | 
 | `-u <UID>:<GID>` | Add user identifiers to run the container with user priviledges. To obtain such values, run on your host `id yourusername`, additional information can be found in [Docker documentation](https://docs.docker.com/engine/reference/commandline/exec/#options)
 | `-p 3129:3129` | This Network port is required for Direct Connection mode, more information in [this section](https://github.com/jaymoulin/docker-jdownloader#direct-connection) |

--- a/configure.sh
+++ b/configure.sh
@@ -7,10 +7,10 @@ if [ ! $# -eq 2 ]; then
     exit 1
 fi
 
-if [ ! -f /opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json ]; then
-    cp /opt/JDownloader/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json.dist /opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
+if [ ! -f /opt/JDownloader/app/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json ]; then
+    cp /opt/JDownloader/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json.dist /opt/JDownloader/app/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
 fi
 
-sed -Ei "s/\"password\" : .+\"(,?)/\"password\" : \"$2\"\1/" /opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json && \
-sed -Ei "s/\"email\" : .+\"(,?)/\"email\" : \"$1\"\1/" /opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
+sed -Ei "s/\"password\" : .+\"(,?)/\"password\" : \"$2\"\1/" /opt/JDownloader/app/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json && \
+sed -Ei "s/\"email\" : .+\"(,?)/\"email\" : \"$1\"\1/" /opt/JDownloader/app/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
 pkill -f "JDownloader"

--- a/daemon.sh
+++ b/daemon.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 trap 'kill -TERM $PID' TERM INT
-rm -f /opt/JDownloader/JDownloader.jar.*
-rm -f /opt/JDownloader/JDownloader.pid
+rm -f /opt/JDownloader/app/JDownloader.jar.*
+rm -f /opt/JDownloader/app/JDownloader.pid
 
 # Login user with env credentials - Please prefer command way
 if [ -n "$MYJD_USER" ] && [ -n "$MYJD_PASSWORD" ]; then
@@ -11,7 +11,7 @@ fi
 
 # Defining device name to jdownloader interface - please prefer this method than changing on MyJDownloader to keep correct binding
 if [ -n "$MYJD_DEVICE_NAME" ]; then
-    sed -Ei "s/\"devicename\" : .+\"(,?)/\"devicename\" : \"$MYJD_DEVICE_NAME\"\1/" /opt/JDownloader/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
+    sed -Ei "s/\"devicename\" : .+\"(,?)/\"devicename\" : \"$MYJD_DEVICE_NAME\"\1/" /opt/JDownloader/app/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json
 fi
 
 # Debugging helper - if the container crashes, create a file called "jdownloader-block.txt" in the download folder
@@ -20,21 +20,25 @@ if [ -f /opt/JDownloader/Downloads/jdownloader-block.txt ]; then
     sleep 1000000
 fi
 
+# Copy libs if not copied yet
+if [ ! -f /opt/JDownloader/app/libs/sevenzipjbinding1509.jar ]; then
+    cp /opt/JDownloader/libs/*.jar /opt/JDownloader/app/libs/
+fi
+
+# Copy if no JDownloader exists
+if [ ! -f /opt/JDownloader/app/JDownloader.jar ]; then
+    cp /opt/JDownloader/JDownloader.jar /opt/JDownloader/app/
+fi
+
 # Check JDownloader.jar integrity and removes it in case it's not
-jar tvf /opt/JDownloader/JDownloader.jar > /dev/null 2>&1
+jar tvf /opt/JDownloader/app/JDownloader.jar > /dev/null 2>&1
 if [ $? -ne 0 ]; then
-    rm /opt/JDownloader/JDownloader.jar
+    rm /opt/JDownloader/app/JDownloader.jar
 fi
 
 # Check if JDownloader.jar exists, or if there is an interrupted update
-if [ ! -f /opt/JDownloader/JDownloader.jar ] && [ -f /opt/JDownloader/tmp/update/self/JDU/JDownloader.jar ]; then
-    cp /opt/JDownloader/tmp/update/self/JDU/JDownloader.jar /opt/JDownloader/
-fi
-
-# Redownload if no JDownloader exists
-if [ ! -f /opt/JDownloader/JDownloader.jar ]; then
-    wget -O /opt/JDownloader/JDownloader.jar "http://installer.jdownloader.org/JDownloader.jar"
-    chmod +x /opt/JDownloader/JDownloader.jar
+if [ ! -f /opt/JDownloader/app/JDownloader.jar ] && [ -f /opt/JDownloader/app/tmp/update/self/JDU/JDownloader.jar ]; then
+    cp /opt/JDownloader/app/tmp/update/self/JDU/JDownloader.jar /opt/JDownloader/app/
 fi
 
 # Defines umask - should respect octal format
@@ -43,7 +47,7 @@ if echo "$UMASK" | grep -Eq '0[0-7]{3}' ; then
     umask "$UMASK"
 fi
 
-java -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8 -Djava.awt.headless=true -jar /opt/JDownloader/JDownloader.jar -norestart &
+java -Dsun.jnu.encoding=UTF-8 -Dfile.encoding=UTF-8 -Djava.awt.headless=true -jar /opt/JDownloader/app/JDownloader.jar -norestart &
 PID=$!
 wait $PID
 wait $PID


### PR DESCRIPTION
This PR moves the main app to a separate folder (`app`). This way this directory can be mounted as a volume which persists the data after an update.

THIS IS A BREAKING CHANGE! Because of the extra directory layer the mounts has to be changed.

I've created an image and tested this on my Kubernetes cluster. A small example for a pod:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: jdownloader
  labels:
    app: jdownloader
spec:
  replicas: 1
  selector:
    matchLabels:
      app: jdownloader
  template:
    metadata:
      labels:
        app: jdownloader
    spec:
      containers:
        - name: jdownloader
          image: jaymoulin/jdownloader
          env:
            - name: MYJD_USER
              value: "email@email.com"
            - name: MYJD_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: my_jd_secret
                  key: password
          volumeMounts:
            - mountPath: /opt/JDownloader/app
              name: exec
            - mountPath: /opt/JDownloader/app/cfg
              name: cfg
            - mountPath: /opt/JDownloader/Downloads
              name: downloads
      volumes:
        - name: exec
          emptyDir: {}
        - name: cfg
          hostPath:
            path: /path/to/jd/cfg
            type: Directory
        - name: downloads
          hostPath:
            path: /path/to/downloads
            type: Directory
```


Fixes: https://github.com/jaymoulin/docker-jdownloader/issues/94, https://github.com/jaymoulin/docker-jdownloader/issues/91, https://github.com/jaymoulin/docker-jdownloader/issues/82 and maybe other related.