### PR TITLE
Update daemon.sh and the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,23 @@ services:
         - </path/to/appdata/extensions>:/opt/JDownloader/app/extensions #optional
         - /etc/localtime:/etc/localtime:ro #optional
     environment: 
+            FILE_MYJD_USER: myjd-user #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
+            FILE_MYJD_PASSWORD: myjd-password #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
             MYJD_USER: email@email.com #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
             MYJD_PASSWORD: bar #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
             MYJD_DEVICE_NAME: goofy #optional
             XDG_DOWNLOAD_DIR: /opt/JDownloader/Downloads #optional
     ports:
         - 3129:3129 
+    secrets:
+        - myjd-user #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
+        - myjd-password #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
+
+secrets:
+  myjd-user: #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
+    file: ~/jdownloader/secrets/myjd_user.txt
+  myjd-password: #optional (see [Identify](https://github.com/jaymoulin/docker-jdownloader#identify))
+    file: ~/jdownloader/secrets/myjd_password.txt
 ```
 
 ### Kubernetes
@@ -125,6 +136,8 @@ You can set many parameters when you configure this container, but you must spec
 ### Environment Variables
 | Parameter | Function |
 | :----: | --- |
+| `FILE_MYJD_USER=myjd-user` | The docker secret of your MyJDownloader user |
+| `FILE_MYJD_PASSWORD=myjd-password` | The docker secret of your MyJDownloader password |
 | `MYJD_USER=email@email.com` | Your MyJDownloader user |
 | `MYJD_PASSWORD=foo` | Your MyJDownloader password |
 | `MYJD_DEVICE_NAME=goofy`| The device name that will appear on MyJdownloader portal |
@@ -132,7 +145,10 @@ You can set many parameters when you configure this container, but you must spec
 | `UMASK="0002"` | Defines specific rights for your downloaded files (default: undefined) - Must respect octal form (begins with 0 followed by three numbers between 0 and 7 included) (cf. https://en.wikipedia.org/wiki/Umask) |
 
 #### Identify
-If haven't set MYJD_USER and MYJD_PASSWORD values, you can still configure an account by running (Recommended method)
+There are 3 possibilities to give login password for MyJDownloader:
+- Declare FILE_MYJD_USER and FILE_MY_JD_PASSWORD which is used with the principle of docker secret : https://docs.docker.com/engine/swarm/secrets/#use-secrets-in-compose. This is the most docker way.
+- Declare MYJD_USER and MYJD_PASSWORD values which only create environment variable
+- If haven't set FILE_MYJD_USER, FILE_MY_JD_PASSWORD, MYJD_USER and MYJD_PASSWORD values, you can still configure an account by running (Recommended method because it is the most secure but not fully automatic in the docker-compose.)
 
 ```
 docker exec jdownloader configure email@email.com password

--- a/daemon.sh
+++ b/daemon.sh
@@ -4,8 +4,10 @@ trap 'kill -TERM $PID' TERM INT
 rm -f /opt/JDownloader/app/JDownloader.jar.*
 rm -f /opt/JDownloader/app/JDownloader.pid
 
-# Login user with env credentials - Please prefer command way
-if [ -n "$MYJD_USER" ] && [ -n "$MYJD_PASSWORD" ]; then
+# Login user with docker secret or env credentials - Please prefer command way
+if [ -n "$FILE_MYJD_USER" ] && [ -n "$FILE_MYJD_PASSWORD" ]; then
+    configure $(cat "/run/secrets/$FILE_MYJD_USER") $(cat "/run/secrets/$FILE_MYJD_PASSWORD")
+elif [ -n "$MYJD_USER" ] && [ -n "$MYJD_PASSWORD" ]; then
     configure "$MYJD_USER" "$MYJD_PASSWORD"
 fi
 


### PR DESCRIPTION
Add the possibility to use docker secret for swarm or compose.

It's related to the ticket #121 

I validate the build on my computer.
I didn't change the version of the application.

Here an example of docker-compose :
```
version: "3.4"
services:
  # JDownloader 2
  jdownloader:
    image: jaymoulin/jdownloader:2.0.3-amd64
    container_name: jdownloader2
    environment:
      - PUID=${PUID}
      - PGID=${PGID}
      - TZ=${TZ}
      - FILE_MYJD_USER=myjd-user
      - FILE_MYJD_PASSWORD=myjd-pass
      - MYJD_DEVICE_NAME=jdownloader@MY_COMPUTER
    volumes:
      - jdownloader2/config:/opt/JDownloader/app/cfg
      - download//jdownloader2:/opt/JDownloader/Downloads
      - /etc/localtime:/etc/localtime:ro
    secrets:
       - myjd-user
       - myjd-pass
    restart: unless-stopped

secrets:
  myjd-user:
    file: jdownloader2/secrets/myjd_user.txt
  myjd-pass:
    file: jdownloader2/secrets/myjd_pass.txt
```

The folder structure : 
```
.
├── docker-compose.yml
├── download
│   ├── jdownloader2
├── jdownloader2
│   ├── config
│   └── secrets
│       ├── myjd_pass.txt
│       └── myjd_user.txt

```
